### PR TITLE
Update features.md

### DIFF
--- a/v1/features.md
+++ b/v1/features.md
@@ -32,7 +32,7 @@ class TestChild extends TestParent
 	{
 		// Дополним свойство needModules, что бы не потерять настройки родительского класса
 		// Подключаем модули веб-формы и поиск
-		$this->needModules += ['form', 'search'];
+		$this->needModules = array_unique(array_merge($this->needModules, ['form', 'search']));
 
 		return parent::onPrepareComponentParams($params);
 	}


### PR DESCRIPTION
Более корректный пример дополнения `$this->needModules` при наследовании.

Старый будет с большой вероятностью работать не правильно: объединение массивов пропускает числовые ключи, которые уже есть в исходном массиве.

``` php
// $this->needModules == ['iblock'];

$this->needModules += ['form', 'search'];
// $this->needModules == ['iblock', 'search']

$this->needModules = array_unique(array_merge($this->needModules, ['form', 'search']));
// $this->needModules == ['iblock', 'form', 'search']
```
